### PR TITLE
feat: introduce CalVer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,20 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # VersionIt - Version Management Library
 
-Lightweight Version Management library, currently only supporting [SemVer 2.0.0]
+Lightweight Version Management library for managing [Semantic Versioning](#semantic-versioning) and [Calendar Versioning](#calendar-versioning)
 
 ## Features
 
 * Simple to use
-* Supports the [SemVer 2.0.0] specification
+* Supports [Semantic Versioning](#semantic-versioning)
   * Extended with key-value pair support in the `BUILD` and `PRERELEASE` identifier (e.g. `0.1.0-rc.1 < 0.1.0-rc.2`, `0.2.3-rc.3+build.2 < 0.2.3-rc.3+build.3` )
-## Basic Usage
+* Supports [Calendar Versioning]
+  * Extended with key-value pair support in the `MODIFIER` identifier (e.g. `2023.25.1-build.1`)
+
+
+## Semantic Versioning
+
+> :bulb: Please refer to the [SemVer 2.0.0] specification for information about Semantic Versioning.
 
 ```typescript
 import { SemVer } from "@dev-build-deploy/version-it";
@@ -30,7 +36,84 @@ const previousVersion = new SemVer({
 
 // Increment the version
 const newVersion = currentVersion.increment("preRelease");
+```
 
+### Incrementing the version
+
+The following increment types can be applied when using `.increment(...)`:
+
+| Type | Description |
+| --- | --- |
+| `major` | Increments the `MAJOR` version core |
+| `minor` | Increments the `MINOR` version core |
+| `patch` | Increments the `PATCH` version core |
+| `preRelease` | Increments the `PRERELEASE` or adds `-rc.1` in case no `PRERELEASE` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `-alpha.1`, `-rc.7`) |
+| `build` | Increments the `BUILD` or adds `+build.1` in case no `BUILD` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `+build.1`, `+attempt.3`) |
+
+## Calendar Versioning
+
+> :bulb: Please refer to the [CalVer] specification for information about Calendar Versioning.
+
+```ts
+import { CalVer } from "@dev-build-deploy/version-it";
+
+const calverFormat = "YYYY.0M.MICRO";
+
+// Create from string
+const currentVersion = new CalVer(calverFormat, "2023.01.12-alpha.2");
+
+// Create from interface
+const previousVersion = new CalVer(
+  calverFormat, {
+    major: 2023,
+    minor: 1,
+    micro: 12,
+    modified: "alpha.1"
+  }
+);
+
+// Update the calendar related version (e.g. YYYY, MM, WW, DD)
+const newVersion = currentVersion.increment("CALENDAR");
+```
+
+### CalVer Formatting
+
+> **NOTE**: Wwe only support CalVer formatting with 2 or 3 version cores.
+
+Formatting is provided as a string, where each version core (`MAJOR`, `MINOR`, `MICRO`) can be assigned to a specific format:
+
+| Format | Description |
+| --- | --- |
+| `YYYY` | Full year |
+| `YY` | Last three digits of the year (e.g. 3, 23, 101)
+| `0Y` | Zero padded last three digits of the year (e.g. 003, 023, 101)
+| `MM` | Month number |
+| `0M` | Zero padded month number |
+| `WW` | Week number (according to ISO8601) |
+| `0W` | Zero padded week number (according to ISO8601) |
+| `DD` | Day of the month |
+| `0D` | Zero padded day of the month |
+| `MAJOR` | Incremental number |
+| `MINOR` | Incremental number |
+| `MICRO` | Incremental number |
+
+### Incrementing the version
+
+The following increment types can be applied when using `.increment(...)`:
+
+| Type | Description |
+| --- | --- |
+| `CALENDAR` | Updates any version core associated with calendar-related formatting.<br><br>Adds the `build.1` modifier in case the exact version already exists |
+| `MAJOR` | Increments (+1) the version associated with `MAJOR` formatting |
+| `MINOR` | Increments (+1) the version associated with `MINOR` formatting |
+| `MICRO` | Increments (+1) the version associated with `MICRO` formatting |
+| `MODIFIER` | Increments the `MODIFIER` or adds `build.1` in case no `MODIFIER` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `alpha.1`, `build.7`)|
+
+## Comparing and sorting
+
+Both [SemVer](#semantic-versioning) and [CalVer](#calendar-versioning) can be compared and/or sorted in the same manner:
+
+```typescript
 // Sort versions...
 const unsortedVersions = [
   previousVersion,
@@ -61,3 +144,4 @@ For more, check out the [Contributing Guide](CONTRIBUTING.md).
 - [GPL-3.0-or-later AND CC0-1.0](LICENSE) © 2023 Kevin de Jong \<monkaii@hotmail.com\>
 
 [SemVer 2.0.0]: https://semver.org
+[CalVer]: https://calver.org

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "GPL-3.0-or-later",
   "keywords": [
     "Versioning",
-    "SemVer"
+    "SemVer",
+    "CalVer"
   ],
   "repository": {
     "type": "git",

--- a/src/calver.ts
+++ b/src/calver.ts
@@ -1,0 +1,362 @@
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+import { IVersion } from "./interfaces";
+import { getISO8601WeekNumber, getKeyValuePair } from "./utils";
+
+/**
+ * CalVer formats
+ * @type CalVerFormat
+ * @member YYYY Year (e.g. 2022)
+ * @member YY Year (e.g. 22)
+ * @member 0Y Year (e.g. 22)
+ * @member MM Month (e.g. 1)
+ * @member 0M Month (e.g. 01)
+ * @member WW Week (e.g. 1)
+ * @member 0W Week (e.g. 01)
+ * @member DD Day (e.g. 1)
+ * @member 0D Day (e.g. 01)
+ * @member MAJOR Major version
+ * @member MINOR Minor version
+ * @member MICRO Micro version
+ */
+type CalVerFormat = "YYYY" | "YY" | "0Y" | "MM" | "0M" | "WW" | "0W" | "DD" | "0D" | "MAJOR" | "MINOR" | "MICRO";
+
+/**
+ * CalVer increments
+ * @type CalVerIncrement
+ * @member calendar Increments the calendar (i.e. YYYY, MM, WW, DD)
+ * @member major Increments the major version
+ * @member minor Increments the minor version
+ * @member micro Increments the micro version
+ * @member modifier Increments the modifier
+ */
+type CalVerIncrement = "CALENDAR" | "MAJOR" | "MINOR" | "MICRO" | "MODIFIER";
+
+/**
+ * CalVer format
+ * @interface IFormat
+ * @member regex Regex used to parse the CalVer
+ * @member major Major version format
+ * @member minor Minor version format
+ * @member micro Micro version format
+ */
+export interface IFormat {
+  regex: RegExp;
+  major: CalVerFormat;
+  minor: CalVerFormat;
+  micro?: CalVerFormat;
+}
+
+/**
+ * A simple CalVer implementation
+ * @interface ICalVer
+ * @member major Major version
+ * @member minor Minor version
+ * @member micro Micro version
+ * @member modifier Modifier
+ * @member prefix Prefix
+ */
+export interface ICalVer {
+  prefix?: string;
+  major: number;
+  minor: number;
+  micro?: number;
+  modifier?: string;
+}
+
+/**
+ * A simple CalVer implementation
+ * @class CalVer
+ * @member major Major version
+ * @member minor Minor version
+ * @member micro Micro version
+ * @member modifier Modifier
+ * @method toString Returns the CalVer as a string
+ * @method increment Increments the CalVer by the provided type
+ */
+export class CalVer implements IVersion<CalVer, CalVerIncrement>, ICalVer {
+  prefix?: string;
+  major: number;
+  minor: number;
+  micro?: number;
+  modifier?: string;
+  format: IFormat;
+
+  constructor(format: string | IFormat, version?: string | Partial<ICalVer>, prefix?: string) {
+    this.format = typeof format === "string" ? formatFromString(format) : format;
+
+    if (typeof version === "string") {
+      if (prefix !== undefined) {
+        if (!version.startsWith(prefix)) throw new Error("Incorrect CalVer, missing prefix");
+        version = version.substring(prefix.length);
+      }
+
+      const groups = this.format.regex.exec(version)?.groups;
+      if (groups === undefined) {
+        throw new Error("Could not parse CalVer");
+      }
+
+      this.prefix = prefix;
+      this.major = parseInt(groups.major);
+      this.minor = parseInt(groups.minor);
+      this.micro = parseInt(groups.micro);
+      this.modifier = groups.modifier;
+    } else {
+      this.prefix = version?.prefix ?? prefix;
+      this.major = version?.major ?? 0;
+      this.minor = version?.minor ?? 0;
+      this.micro = version?.micro ?? (this.format.micro ? 0 : undefined);
+      this.modifier = version?.modifier ?? undefined;
+    }
+  }
+
+  /**
+   * Increments the modifier (in format "key.value") by 1.
+   * If no modifier is available, it will return "build.1"
+   * @returns Incremented modifier
+   */
+  private incrementModifier(): string | undefined {
+    if (this.modifier === undefined) return "build.1";
+
+    const keyValue = getKeyValuePair(this.modifier);
+    if (keyValue === undefined) throw new Error("Cannot increment modifiers without a key/value pair");
+
+    return `${keyValue.key}.${keyValue.value + 1}`;
+  }
+
+  /**
+   * Updates versions associated with calendar items (i.e. YYYY, MM, WW, DD)
+   * in the provided CalVer format.
+   * @param format The CalVer format
+   * @returns The updated version based on the current date.
+   */
+  private updateCalendar(format?: CalVerFormat): number | undefined {
+    if (format === undefined || ["MAJOR", "MINOR", "MICRO"].includes(format)) return;
+
+    if (format.includes("Y")) return new Date().getFullYear();
+    if (format.includes("M")) return new Date().getMonth() + 1;
+    if (format.includes("W")) return getISO8601WeekNumber();
+    if (format.includes("D")) return new Date().getDate() + 1;
+
+    return;
+  }
+
+  /**
+   * Returns a string, where the value is formatted correctly based on the provided format.
+   * @param value Value to format
+   * @param format CalVer format to use
+   * @returns Formatted value
+   */
+  private formatVersionCore(value: number, format: CalVerFormat) {
+    if (["MAJOR", "MINOR", "MICRO"].includes(format)) return value.toString();
+    if (format === "YYYY") return value.toString().padStart(4, "0");
+    if (format === "0Y")
+      return value
+        .toString()
+        .substring(value.toString().length - 3)
+        .padStart(3, "0");
+    if (format.includes("0"))
+      return value
+        .toString()
+        .substring(value.toString().length - 2)
+        .padStart(2, "0");
+
+    return value.toString().substring(value.toString().length - 2);
+  }
+
+  /**
+   * Returns the CalVer as a string
+   * @returns CalVer as a string
+   */
+  toString(): string {
+    let version = this.prefix ?? "";
+
+    version += `${this.formatVersionCore(this.major, this.format.major)}.${this.formatVersionCore(
+      this.minor,
+      this.format.minor
+    )}`;
+
+    if (this.micro !== undefined && this.format.micro !== undefined)
+      version += `.${this.formatVersionCore(this.micro, this.format.micro)}`;
+
+    if (this.modifier !== undefined) version += `-${this.modifier}`;
+
+    return version;
+  }
+
+  /**
+   * Increments the CalVer by the provided type;
+   *   - "calendar": Increments the calendar (i.e. YYYY, MM, WW, DD)
+   *   - "major": Increments the major version
+   *   - "minor": Increments the minor version
+   *   - "micro": Increments the micro version
+   *   - "modifier": Increments the modifier
+   * @param type Type of increment
+   * @returns Incremented CalVer
+   */
+  increment(type: CalVerIncrement): CalVer {
+    switch (type) {
+      case "CALENDAR": {
+        // Increment the calendar only, this allows us to validate whether the calendar has changed
+        const newVersion = new CalVer(this.format, {
+          prefix: this.prefix,
+          major: this.updateCalendar(this.format.major) ?? this.major,
+          minor: this.updateCalendar(this.format.minor) ?? this.minor,
+          micro: this.updateCalendar(this.format.micro) ?? this.micro,
+          modifier: this.modifier,
+        });
+
+        // Increment the modifier if the calendar has not changed
+        if (newVersion.isEqualTo(this)) return new CalVer(this.format, { ...this, modifier: this.incrementModifier() });
+
+        // If the calendar items are updated, reset MAJOR, MINOR, MICRO...
+        for (const subtype of ["major", "minor", "micro"] as (keyof ICalVer)[]) {
+          const filter = Object.keys(this.format).filter(
+            key => this.format[key as keyof IFormat] === subtype.toUpperCase()
+          );
+          if (filter.length !== 1) continue;
+
+          newVersion[filter[0].toLowerCase() as "major" | "minor" | "micro"] = 0;
+        }
+        // ... and MODIFIER
+        newVersion.modifier = undefined;
+
+        return newVersion;
+      }
+
+      case "MAJOR":
+      case "MINOR":
+      case "MICRO": {
+        const filter = Object.keys(this.format).filter(key => this.format[key as keyof IFormat] === type.toUpperCase());
+        if (filter.length !== 1) throw new Error(`Unable to increment ${type} version as it is not part of the format`);
+
+        const item = filter[0].toLowerCase() as "major" | "minor" | "micro";
+        if (item === "major") return new CalVer(this.format, { major: this.major + 1, modifier: undefined });
+        if (item === "minor")
+          return new CalVer(this.format, { major: this.major, minor: this.minor + 1, modifier: undefined });
+        if (item === "micro")
+          return new CalVer(this.format, {
+            major: this.major,
+            minor: this.minor,
+            micro: (this.micro ?? 0) + 1,
+            modifier: undefined,
+          });
+        throw new Error("Unknown increment type.");
+      }
+      case "MODIFIER":
+        return new CalVer(this.format, { ...this, modifier: this.incrementModifier() });
+    }
+  }
+
+  /**
+   * Confirms that the provided format is identical to the current format
+   * @param other Other format to compare against
+   * @returns True if the formats are identical, false otherwise
+   */
+  private isFormatIdentical(other: IFormat): boolean {
+    return this.format.major === other.major && this.format.minor === other.minor && this.format.micro === other.micro;
+  }
+
+  isEqualTo(other: CalVer): boolean {
+    return this.compareTo(other) === 0;
+  }
+  isGreaterThan(other: CalVer): boolean {
+    return this.compareTo(other) === 1;
+  }
+  isLessThan(other: CalVer): boolean {
+    return this.compareTo(other) === -1;
+  }
+
+  /**
+   * Returns 0 when current version is equal to the provided version,
+   * 1 when current version is greater than the provided version,
+   * and -1 when current version is less than the provided version.
+   *
+   * Resulting in the following ordering (taking `YYYY.0M.MICRO` as an example):
+   *
+   * 2022.03.1
+   * 2022.03.2
+   * 2022.11.1
+   * 2022.11.1-alpha.1
+   * 2022.11.1-alpha.2
+   * 2022.11.1-beta.1
+   * 2022.11.2
+   * 2023.01.1
+   *
+   * @param other CalVer to compare to
+   * @returns
+   */
+  compareTo(other: CalVer): number {
+    if (!this.isFormatIdentical(other.format)) throw new Error("Unable to compare CalVer with different formats");
+
+    if (this.major > other.major) return 1;
+    if (this.major < other.major) return -1;
+
+    if (this.minor > other.minor) return 1;
+    if (this.minor < other.minor) return -1;
+
+    if (this.micro !== undefined && other.micro !== undefined) {
+      if (this.micro > other.micro) return 1;
+      if (this.micro < other.micro) return -1;
+    }
+
+    if (this.modifier !== undefined && other.modifier === undefined) return 1;
+    if (this.modifier === undefined && other.modifier !== undefined) return -1;
+
+    if (this.modifier !== undefined && other.modifier !== undefined) {
+      const aModifier = getKeyValuePair(this.modifier);
+      const bModifier = getKeyValuePair(other.modifier);
+      if (aModifier !== undefined && bModifier !== undefined) {
+        if (aModifier.key !== bModifier.key) return aModifier.key.localeCompare(bModifier.key);
+        if (aModifier.value > bModifier.value) return 1;
+        if (aModifier.value < bModifier.value) return -1;
+      } else {
+        return this.modifier.localeCompare(other.modifier);
+      }
+    }
+
+    return 0;
+  }
+}
+
+/**
+ * Generates a regex based on the provided CalVer format
+ * @param format The CalVer format
+ * @returns The regex
+ * @internal
+ */
+export function formatFromString(format: string): IFormat {
+  const elements = /^(?<major>[A-Z0]+)\.(?<minor>[A-Z0]+)(\.(?<micro>[A-Z0]+))?$/.exec(format)?.groups;
+  if (elements === undefined) throw new Error(`Invalid CalVer format: ${format}`);
+
+  const usedElements: string[] = [];
+  const versions: string[] = [];
+  for (const key of Object.keys(elements)) {
+    if (elements[key] === undefined) continue;
+
+    if (usedElements.includes(elements[key])) {
+      throw new Error(`Duplicate CalVer format element: ${elements[key]}`);
+    }
+
+    if (["MAJOR", "MINOR", "MICRO"].includes(elements[key])) versions.push(`(?<${key}>\\d+)`);
+    else if (elements[key] === "YYYY") versions.push(`(?<${key}>\\d{4})`);
+    else if (elements[key] === "YY") versions.push(`(?<${key}>\\d{1,3})`);
+    else if (elements[key] === "0Y") versions.push(`(?<${key}>\\d{3})`);
+    else if (["0M", "0W", "0D"].includes(elements[key])) versions.push(`(?<${key}>\\d{2})`);
+    else if (["MM", "WW", "DD"].includes(elements[key])) versions.push(`(?<${key}>\\d{1,2})`);
+    else throw new Error(`Unknown CalVer format element: ${elements}, ${key}, ${elements[key]}`);
+
+    usedElements.push(elements[key]);
+  }
+
+  return {
+    regex: new RegExp(`^${versions.join(".")}(-(?<modifier>[\\w._]+))?$`),
+    major: elements.major as CalVerFormat,
+    minor: elements.minor as CalVerFormat,
+    micro: elements.micro as CalVerFormat,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ SPDX-License-Identifier: GPL-3.0-or-later
 */
 
 export { ISemVer, SemVer } from "./semver";
+export { ICalVer, CalVer } from "./calver";

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -22,7 +22,6 @@ type SemVerVersionCore = "major" | "minor" | "patch";
  * @member patch Patch version
  * @member preRelease Pre-release identifier
  * @member build Build identifier
- * @method toString Returns the SemVer as a string
  */
 export interface ISemVer {
   prefix?: string;
@@ -43,7 +42,6 @@ export interface ISemVer {
  * @member preRelease Pre-release identifier
  * @member build Build identifier
  * @method toString Returns the SemVer as a string
- * @throws Error Unable to parse version
  */
 export class SemVer implements IVersion<SemVer, keyof ISemVer>, ISemVer {
   prefix?: string;
@@ -148,7 +146,7 @@ export class SemVer implements IVersion<SemVer, keyof ISemVer>, ISemVer {
   }
 
   /**
-   * Function which returns 0 when current version is equal to the provided version,
+   * Returns 0 when current version is equal to the provided version,
    * 1 when current version is greater than the provided version,
    * and -1 when current version is less than the provided version.
    *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,10 +10,27 @@ SPDX-License-Identifier: GPL-3.0-or-later
  * @returns Identifier value (e.g. 1)
  * @internal
  */
-export function getKeyValuePair(value?: string): { key?: string; value?: number } | undefined {
+export function getKeyValuePair(value?: string): { key: string; value: number } | undefined {
   const kvpRegex = /^([a-zA-Z-]+)[.]([0-9]+)$/;
   const match = kvpRegex.exec(value ?? "");
   if (match === null) return;
 
   return { key: match[1], value: parseInt(match[2]) };
+}
+
+/**
+ * Returns the week number of the current date (ISO 8601)
+ * @returns The week number of the current date
+ * @internal
+ */
+export function getISO8601WeekNumber(): number {
+  const date = new Date();
+  const dayNumber = (date.getDay() + 6) % 7;
+  date.setDate(date.getDate() - dayNumber + 3);
+  const firstThursday = date.valueOf();
+  date.setMonth(0, 1);
+  if (date.getDay() !== 4) {
+    date.setMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
+  }
+  return 1 + Math.ceil((firstThursday - date.valueOf()) / 604800000);
 }

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -1,0 +1,261 @@
+/* 
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+import * as calver from "../src/calver";
+
+describe("CalVer Format", () => {
+  test("Validate Regex", () => {
+    expect(calver.formatFromString("YYYY.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{4}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("YY.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{1,3}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("0Y.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{3}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("MM.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{1,2}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("0M.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{2}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("WW.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{1,2}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("0W.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{2}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("DD.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{1,2}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("0D.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{2}).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("MAJOR.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d+).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("MINOR.DD").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d+).(?<minor>\\d{1,2})(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("MICRO.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d+).(?<minor>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(calver.formatFromString("YYYY.MAJOR.MINOR").regex).toStrictEqual(
+      new RegExp("^(?<major>\\d{4}).(?<minor>\\d+).(?<micro>\\d+)(-(?<modifier>[\\w._]+))?$")
+    );
+    expect(() => calver.formatFromString("YYYY.MAJOR.MINOR.MAJOR").regex).toThrow();
+    expect(() => calver.formatFromString("DOES.NOT.EXIST").regex).toThrow();
+    expect(() => calver.formatFromString("YYYY").regex).toThrow();
+    expect(() => calver.formatFromString("YYYY.MM.DD.").regex).toThrow();
+    expect(() => calver.formatFromString("MM.MM").regex).toThrow();
+  });
+
+  test("Validate elements", () => {
+    const elements = ["YYYY", "YY", "0Y", "MM", "0M", "WW", "0W", "DD", "0D", "MAJOR", "MINOR", "MICRO"];
+
+    for (const major of elements) {
+      for (const minor of elements) {
+        for (const micro of elements) {
+          // Skip duplicate entries
+          if (major === minor || major === micro || minor === micro) continue;
+
+          const format = calver.formatFromString(`${major}.${minor}.${micro}`);
+          expect(format.major).toBe(major);
+          expect(format.minor).toBe(minor);
+          expect(format.micro).toBe(micro);
+        }
+      }
+    }
+  });
+});
+
+describe("String to CalVer", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2023, 3, 12));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test("Versions", () => {
+    const versions = [
+      ["2023.1", "YYYY.MINOR"],
+      ["23.1", "YY.MINOR"],
+      ["001.1", "0Y.MINOR"],
+      ["3.1", "MM.MINOR"],
+      ["03.1", "0M.MINOR"],
+      ["12.1", "WW.MINOR"],
+      ["07.1", "0W.MINOR"],
+      ["9.1", "DD.MINOR"],
+      ["09.1", "0D.MINOR"],
+      ["500.1", "MAJOR.MINOR"],
+      ["66666.1", "MINOR.MAJOR"],
+      ["100000.1", "MICRO.MINOR"],
+    ];
+
+    for (const [version, format] of versions) {
+      expect(new calver.CalVer(format, version).toString()).toBe(version);
+    }
+  });
+
+  test("Update Calendar", () => {
+    const versions = [
+      // New versions
+      ["2022.1", "YYYY.MINOR", "2023.0"],
+      ["22.1", "YY.MINOR", "23.0"],
+      ["001.1", "0Y.MINOR", "023.0"],
+      ["1.1", "MM.MINOR", "4.0"],
+      ["01.1", "0M.MICRO", "04.0"],
+      ["3.1", "WW.MINOR", "15.0"],
+      ["03.1", "0W.MINOR", "15.0"],
+      ["7.1", "DD.MINOR", "13.0"],
+      ["07.1", "0D.MINOR", "13.0"],
+      ["07.1.3", "0D.MAJOR.MINOR", "13.0.0"],
+      // Equal versions
+      ["2023.1", "YYYY.MINOR", "2023.1-build.1"],
+      ["2023.1-build.1", "YYYY.MINOR", "2023.1-build.2"],
+    ];
+
+    for (const [version, format, expectations] of versions) {
+      expect(new calver.CalVer(format, version).increment("CALENDAR").toString()).toBe(expectations);
+    }
+  });
+
+  test("Update Major", () => {
+    const versions = [
+      // New versions
+      ["2022.1", "YYYY.MAJOR", "2022.2"],
+      ["22.1", "YY.MAJOR", "22.2"],
+      ["09.1.3", "0D.MAJOR.MINOR", "09.2.0"],
+      // Incorrect increments
+      ["2022.1", "YYYY.MINOR", ""],
+      ["22.1", "YY.DD", ""],
+      ["001.1", "0Y.MINOR", ""],
+      ["1.1", "MM.MICRO", ""],
+      ["01.1", "0M.WW", ""],
+    ];
+
+    for (const [version, format, expectations] of versions) {
+      if (expectations !== "") {
+        expect(new calver.CalVer(format, version).increment("MAJOR").toString()).toBe(expectations);
+      } else {
+        expect(() => new calver.CalVer(format, version).increment("MAJOR")).toThrow();
+      }
+    }
+  });
+
+  test("Update Minor", () => {
+    const versions = [
+      // New versions
+      ["2022.1.2", "YYYY.MAJOR.MINOR", "2022.1.3"],
+      ["22.1", "YY.MINOR", "22.2"],
+      // Incorrect increments
+      ["2022.1", "YYYY.MAJOR", ""],
+      ["22.1", "YY.DD", ""],
+      ["001", "0Y.MAJOR", ""],
+      ["1.1", "MM.MICRO", ""],
+      ["01.1", "0M.WW", ""],
+    ];
+
+    for (const [version, format, expectations] of versions) {
+      if (expectations !== "") {
+        expect(new calver.CalVer(format, version).increment("MINOR").toString()).toBe(expectations);
+      } else {
+        expect(() => new calver.CalVer(format, version).increment("MINOR")).toThrow();
+      }
+    }
+  });
+
+  test("Update Minor", () => {
+    const versions = [
+      // New versions
+      ["2022.1.2", "YYYY.MINOR.MICRO", "2022.1.3"],
+      ["22.1", "YY.MICRO", "22.2"],
+      // Incorrect increments
+      ["2022.1", "YYYY.MAJOR", ""],
+      ["22.1", "YY.DD", ""],
+      ["001.1", "0Y.MAJOR", ""],
+      ["1.1", "MM.MINOR", ""],
+      ["01.1", "0M.WW", ""],
+    ];
+
+    for (const [version, format, expectations] of versions) {
+      if (expectations !== "") {
+        expect(new calver.CalVer(format, version).increment("MICRO").toString()).toBe(expectations);
+      } else {
+        expect(() => new calver.CalVer(format, version).increment("MICRO")).toThrow();
+      }
+    }
+  });
+
+  test("Update Modifier", () => {
+    const versions = [
+      // New versions
+      ["2022.1.2", "YYYY.MAJOR.MINOR", "2022.1.2-build.1"],
+      ["22.1-build.3", "YY.MINOR", "22.1-build.4"],
+      // Incorrect increments
+      ["2022.1-alpha", "YYYY.MAJOR", ""],
+      ["22.1-alpha1", "YY.DD", ""],
+    ];
+
+    for (const [version, format, expectations] of versions) {
+      if (expectations !== "") {
+        expect(new calver.CalVer(format, version).increment("MODIFIER").toString()).toBe(expectations);
+      } else {
+        expect(() => new calver.CalVer(format, version).increment("MODIFIER")).toThrow();
+      }
+    }
+  });
+});
+
+describe("Comparators", () => {
+  test("Exhaustive compare", () => {
+    const versions = [
+      // Two version cores
+      ["YYYY.MAJOR", "2023.1", "2023.1", "0"],
+      ["YYYY.MINOR", "2023.1", "2023.0", "1"],
+      ["YYYY.MICRO", "2023.1", "2023.2", "-1"],
+      ["YY.WW", "23.2", "23.1", "1"],
+      ["YY.0D", "23.02", "23.03", "-1"],
+      // Three version cores
+      ["YYYY.MINOR.MICRO", "2023.1.1", "2023.1.1", "0"],
+      ["YY.MINOR.MICRO", "23.1.2", "23.1.1", "1"],
+      ["WW.MINOR.MICRO", "15.1.2", "15.1.3", "-1"],
+      ["YYYY.0W.0D", "2023.02.02", "2023.01.03", "1"],
+      ["MAJOR.MINOR.MICRO", "2023.2.2", "2023.2.1", "1"],
+      ["MAJOR.MINOR.MICRO", "2023.2.2", "2023.2.3", "-1"],
+      ["MAJOR.MINOR.MICRO", "2022.2.2", "2023.2.2", "-1"],
+      ["MAJOR.MINOR.MICRO", "2024.1.1", "2023.2.2", "1"],
+      // Modifiers
+      ["YYYY.MINOR", "2023.1", "2023.1-build.1", "-1"],
+      ["YYYY.MINOR", "2023.2", "2023.1-build.1", "1"],
+      ["YYYY.MINOR", "2023.1-build.1", "2023.1-build.1", "0"],
+      ["YYYY.MINOR", "2023.1-build.2", "2023.1-build.1", "1"],
+      ["YYYY.MINOR", "2023.1-build.200", "2023.1-build.199", "1"],
+      ["YYYY.MINOR", "2023.1-build.199", "2023.1-build.200", "-1"],
+      ["YYYY.MINOR", "2023.1-build.2", "2023.1-build.3", "-1"],
+      ["YYYY.MINOR", "2023.2-build.1", "2023.1-build.3", "1"],
+      ["YYYY.MINOR", "2023.1-build.5", "2023.2-build.3", "-1"],
+      ["YYYY.MINOR", "2023.1-beta.1", "2023.1-alpha.1", "1"],
+      ["YYYY.MINOR", "2023.1-beta.1", "2023.1-gamma.1", "-1"],
+      ["YYYY.MINOR", "2023.1-beta", "2023.1-alpha.1", "1"],
+      ["YYYY.MINOR", "2023.1-alpha", "2023.1-gamma.1", "-1"],
+      ["YYYY.MINOR", "2023.1-alpha", "2023.1-gamma", "-1"],
+      ["YYYY.MINOR", "2023.1-beta", "2023.1-alpha", "1"],
+    ];
+
+    for (const [format, a, b, expectations] of versions) {
+      const aC = new calver.CalVer(format, a);
+      const bC = new calver.CalVer(format, b);
+      expect(aC.compareTo(bC)).toBe(parseInt(expectations));
+      expect(aC.isEqualTo(bC)).toBe(expectations === "0");
+      expect(aC.isGreaterThan(bC)).toBe(expectations === "1");
+      expect(aC.isLessThan(bC)).toBe(expectations === "-1");
+    }
+  });
+});


### PR DESCRIPTION
This commit introduces the `CalVer` class to manage your Calendar Versioning based versions.

Please refer to the README.md for more details around its usage