### PR TITLE
fix: export SemVer and CalVer increment types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+# SPDX-License-Identifier: CC0-1.0
+
+repos:
+- repo: https://github.com/dev-build-deploy/commit-me
+  rev: v0.12.1
+  hooks:
+  - id: commit-me

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const previousVersion = new SemVer({
 });
 
 // Increment the version
-const newVersion = currentVersion.increment("preRelease");
+const newVersion = currentVersion.increment("PRERELEASE");
 ```
 
 ### Incrementing the version
@@ -44,11 +44,11 @@ The following increment types can be applied when using `.increment(...)`:
 
 | Type | Description |
 | --- | --- |
-| `major` | Increments the `MAJOR` version core |
-| `minor` | Increments the `MINOR` version core |
-| `patch` | Increments the `PATCH` version core |
-| `preRelease` | Increments the `PRERELEASE` or adds `-rc.1` in case no `PRERELEASE` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `-alpha.1`, `-rc.7`) |
-| `build` | Increments the `BUILD` or adds `+build.1` in case no `BUILD` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `+build.1`, `+attempt.3`) |
+| `MAJOR` | Increments the `MAJOR` version core |
+| `MINOR` | Increments the `MINOR` version core |
+| `PATCH` | Increments the `PATCH` version core |
+| `PRERELEASE` | Increments the `PRERELEASE` or adds `-rc.1` in case no `PRERELEASE` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `-alpha.1`, `-rc.7`) |
+| `BUILD` | Increments the `BUILD` or adds `+build.1` in case no `BUILD` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `+build.1`, `+attempt.3`) |
 
 ## Calendar Versioning
 

--- a/src/calver.ts
+++ b/src/calver.ts
@@ -34,7 +34,7 @@ type CalVerFormat = "YYYY" | "YY" | "0Y" | "MM" | "0M" | "WW" | "0W" | "DD" | "0
  * @member micro Increments the micro version
  * @member modifier Increments the modifier
  */
-type CalVerIncrement = "CALENDAR" | "MAJOR" | "MINOR" | "MICRO" | "MODIFIER";
+export type CalVerIncrement = "CALENDAR" | "MAJOR" | "MINOR" | "MICRO" | "MODIFIER";
 
 /**
  * CalVer format
@@ -59,6 +59,7 @@ export interface IFormat {
  * @member micro Micro version
  * @member modifier Modifier
  * @member prefix Prefix
+ * @internal
  */
 export interface ICalVer {
   prefix?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 SPDX-License-Identifier: GPL-3.0-or-later
 */
 
-export { ISemVer, SemVer } from "./semver";
-export { ICalVer, CalVer } from "./calver";
+export { SemVer, SemVerIncrement } from "./semver";
+export { CalVer, CalVerIncrement } from "./calver";
+export { IVersion } from "./interfaces";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -52,7 +52,6 @@ export interface IComparable<T> {
  * @extends IComparable
  * @template T Version type
  * @template Y Increment type
- * @internal
  */
 export interface IVersion<T, Y> extends IComparable<T> {
   /**

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -15,6 +15,17 @@ type SemVerIdentifier = "preRelease" | "build";
 type SemVerVersionCore = "major" | "minor" | "patch";
 
 /**
+ * SemVer increment types
+ * @type SemVerIncrement
+ * @member major Major version
+ * @member minor Minor version
+ * @member patch Patch version
+ * @member preRelease Pre-release identifier
+ * @member build Build identifier
+ */
+export type SemVerIncrement = "MAJOR" | "MINOR" | "PATCH" | "PRERELEASE" | "BUILD";
+
+/**
  * A simple SemVer implementation
  * @interface ISemVer
  * @member major Major version
@@ -22,6 +33,7 @@ type SemVerVersionCore = "major" | "minor" | "patch";
  * @member patch Patch version
  * @member preRelease Pre-release identifier
  * @member build Build identifier
+ * @internal
  */
 export interface ISemVer {
   prefix?: string;
@@ -43,7 +55,7 @@ export interface ISemVer {
  * @member build Build identifier
  * @method toString Returns the SemVer as a string
  */
-export class SemVer implements IVersion<SemVer, keyof ISemVer>, ISemVer {
+export class SemVer implements IVersion<SemVer, SemVerIncrement>, ISemVer {
   prefix?: string;
   major: number;
   minor: number;
@@ -108,20 +120,22 @@ export class SemVer implements IVersion<SemVer, keyof ISemVer>, ISemVer {
    * @param type Type of increment
    * @returns Incremented SemVer
    */
-  increment(type: keyof ISemVer): SemVer {
+  increment(type: SemVerIncrement): SemVer {
     switch (type) {
-      case "preRelease":
-        return new SemVer({ ...this, preRelease: this.incrementIdentifier(type) ?? "rc.1", build: undefined });
-      case "build":
-        return new SemVer({ ...this, preRelease: this.preRelease, build: this.incrementIdentifier(type) ?? "build.1" });
-      case "major":
+      case "PRERELEASE":
+        return new SemVer({ ...this, preRelease: this.incrementIdentifier("preRelease") ?? "rc.1", build: undefined });
+      case "BUILD":
+        return new SemVer({
+          ...this,
+          preRelease: this.preRelease,
+          build: this.incrementIdentifier("build") ?? "build.1",
+        });
+      case "MAJOR":
         return new SemVer({ prefix: this.prefix, major: this.major + 1 });
-      case "minor":
+      case "MINOR":
         return new SemVer({ prefix: this.prefix, major: this.major, minor: this.minor + 1 });
-      case "patch":
+      case "PATCH":
         return new SemVer({ prefix: this.prefix, major: this.major, minor: this.minor, patch: this.patch + 1 });
-      case "prefix":
-        throw new Error("Unable to increment prefix");
     }
   }
 

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -156,60 +156,60 @@ describe("Comparators", () => {
 
 describe("increment version", () => {
   test("increment major", () => {
-    expect(new SemVer("0.0.1")?.increment("major").toString()).toBe("1.0.0");
-    expect(new SemVer("0.1.0")?.increment("major").toString()).toBe("1.0.0");
-    expect(new SemVer("1.0.0")?.increment("major").toString()).toBe("2.0.0");
-    expect(new SemVer("1.0.0-rc.1")?.increment("major").toString()).toBe("2.0.0");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("major").toString()).toBe("2.0.0");
+    expect(new SemVer("0.0.1")?.increment("MAJOR").toString()).toBe("1.0.0");
+    expect(new SemVer("0.1.0")?.increment("MAJOR").toString()).toBe("1.0.0");
+    expect(new SemVer("1.0.0")?.increment("MAJOR").toString()).toBe("2.0.0");
+    expect(new SemVer("1.0.0-rc.1")?.increment("MAJOR").toString()).toBe("2.0.0");
+    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("MAJOR").toString()).toBe("2.0.0");
   });
 
   test("increment minor", () => {
-    expect(new SemVer("0.0.1")?.increment("minor").toString()).toBe("0.1.0");
-    expect(new SemVer("0.1.0")?.increment("minor").toString()).toBe("0.2.0");
-    expect(new SemVer("1.0.0")?.increment("minor").toString()).toBe("1.1.0");
-    expect(new SemVer("1.0.0-rc.1")?.increment("minor").toString()).toBe("1.1.0");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("minor").toString()).toBe("1.1.0");
+    expect(new SemVer("0.0.1")?.increment("MINOR").toString()).toBe("0.1.0");
+    expect(new SemVer("0.1.0")?.increment("MINOR").toString()).toBe("0.2.0");
+    expect(new SemVer("1.0.0")?.increment("MINOR").toString()).toBe("1.1.0");
+    expect(new SemVer("1.0.0-rc.1")?.increment("MINOR").toString()).toBe("1.1.0");
+    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("MINOR").toString()).toBe("1.1.0");
   });
 
   test("increment patch", () => {
-    expect(new SemVer("0.0.1")?.increment("patch").toString()).toBe("0.0.2");
-    expect(new SemVer("0.1.0")?.increment("patch").toString()).toBe("0.1.1");
-    expect(new SemVer("1.0.0")?.increment("patch").toString()).toBe("1.0.1");
-    expect(new SemVer("1.0.0-rc.1")?.increment("patch").toString()).toBe("1.0.1");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("patch").toString()).toBe("1.0.1");
+    expect(new SemVer("0.0.1")?.increment("PATCH").toString()).toBe("0.0.2");
+    expect(new SemVer("0.1.0")?.increment("PATCH").toString()).toBe("0.1.1");
+    expect(new SemVer("1.0.0")?.increment("PATCH").toString()).toBe("1.0.1");
+    expect(new SemVer("1.0.0-rc.1")?.increment("PATCH").toString()).toBe("1.0.1");
+    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("PATCH").toString()).toBe("1.0.1");
   });
 
   test("increment preRelease", () => {
-    expect(new SemVer("0.0.1")?.increment("preRelease").toString()).toBe("0.0.1-rc.1");
-    expect(new SemVer("0.1.0-rc.1")?.increment("preRelease").toString()).toBe("0.1.0-rc.2");
-    expect(new SemVer("1.0.0+build.3")?.increment("preRelease").toString()).toBe("1.0.0-rc.1");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("preRelease").toString()).toBe("1.0.0-rc.3");
+    expect(new SemVer("0.0.1")?.increment("PRERELEASE").toString()).toBe("0.0.1-rc.1");
+    expect(new SemVer("0.1.0-rc.1")?.increment("PRERELEASE").toString()).toBe("0.1.0-rc.2");
+    expect(new SemVer("1.0.0+build.3")?.increment("PRERELEASE").toString()).toBe("1.0.0-rc.1");
+    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("PRERELEASE").toString()).toBe("1.0.0-rc.3");
   });
 
   test("increment build", () => {
-    expect(new SemVer("0.0.1")?.increment("build").toString()).toBe("0.0.1+build.1");
-    expect(new SemVer("0.1.0-rc.1")?.increment("build").toString()).toBe("0.1.0-rc.1+build.1");
-    expect(new SemVer("1.0.0+build.1")?.increment("build").toString()).toBe("1.0.0+build.2");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("build").toString()).toBe("1.0.0-rc.2+build.2");
+    expect(new SemVer("0.0.1")?.increment("BUILD").toString()).toBe("0.0.1+build.1");
+    expect(new SemVer("0.1.0-rc.1")?.increment("BUILD").toString()).toBe("0.1.0-rc.1+build.1");
+    expect(new SemVer("1.0.0+build.1")?.increment("BUILD").toString()).toBe("1.0.0+build.2");
+    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("BUILD").toString()).toBe("1.0.0-rc.2+build.2");
   });
 
   test("Support prefix", () => {
     expect(
       new SemVer("v0.0.0", "v")
-        ?.increment("major")
-        .increment("minor")
-        .increment("patch")
-        .increment("preRelease")
-        .increment("build")
+        ?.increment("MAJOR")
+        .increment("MINOR")
+        .increment("PATCH")
+        .increment("PRERELEASE")
+        .increment("BUILD")
         .toString()
     ).toBe("v1.1.1-rc.1+build.1");
     expect(
       new SemVer("v0.0.0", "v")
-        ?.increment("build")
-        .increment("preRelease")
-        .increment("patch")
-        .increment("minor")
-        .increment("major")
+        ?.increment("BUILD")
+        .increment("PRERELEASE")
+        .increment("PATCH")
+        .increment("MINOR")
+        .increment("MAJOR")
         .toString()
     ).toBe("v1.0.0");
   });


### PR DESCRIPTION
In addition, this change renames the SemVer increment types to capital case iso lower case and drops the "prefix" as increment type.