### PR TITLE
feat!: support management of multiple modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Lightweight Version Management library for managing [Semantic Versioning](#seman
 
 ## Semantic Versioning
 
-> :bulb: Please refer to the [SemVer 2.0.0] specification for information about Semantic Versioning.
+> [!NOTE]
+> Please refer to the [SemVer 2.0.0] specification for information about Semantic Versioning.
 
 ```typescript
 import { SemVer } from "@dev-build-deploy/version-it";
@@ -51,7 +52,7 @@ The following increment types can be applied when using `.increment(...)`:
 
 ## Calendar Versioning
 
-> [!INFO]
+> [!NOTE]
 > Please refer to the [CalVer] specification for information about Calendar Versioning.
 
 ```ts
@@ -78,7 +79,8 @@ const newVersion = currentVersion.increment("CALENDAR"); // => 2024.0.0
 
 ### CalVer Formatting
 
-> **NOTE**: Wwe only support CalVer formatting with 2 or 3 version cores.
+> [!WARNING]
+> We only support CalVer formatting with 2 or 3 version cores.
 
 Formatting is provided as a string, where each version core (`MAJOR`, `MINOR`, `MICRO`) can be assigned to a specific format:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Lightweight Version Management library for managing [Semantic Versioning](#seman
 
 * Simple to use
 * Supports [Semantic Versioning](#semantic-versioning)
-  * Extended with key-value pair support in the `BUILD` and `PRERELEASE` identifier (e.g. `0.1.0-rc.1 < 0.1.0-rc.2`, `0.2.3-rc.3+build.2 < 0.2.3-rc.3+build.3` )
+  * Extended with key-value pair support in the `PRERELEASE` identifier (e.g. `0.1.0-rc.1 < 0.1.0-rc.2` )
 * Supports [Calendar Versioning]
   * Extended with key-value pair support in the `MODIFIER` identifier (e.g. `2023.25.1-build.1`)
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,18 @@ Lightweight Version Management library for managing [Semantic Versioning](#seman
 import { SemVer } from "@dev-build-deploy/version-it";
 
 // Create from string
-const currentVersion = new SemVer("0.1.2-alpha.4");
-
-// Create from interface
-const previousVersion = new SemVer({
-  minor: 1,
-  patch: 2,
-  preRelease: "alpha.3"
-});
+const currentVersion = SemVer.fromString("0.1.2");
 
 // Increment the version
-const newVersion = currentVersion.increment("PRERELEASE");
+const alphaVersion = currentVersion.increment("PRERELEASE", "alpha"); // => 0.1.2-alpha.1
+const majorVersion = currentVersion.increment("MAJOR"); // => 1.0.0
+
+// Create from interface
+const constructed = new SemVer({
+  minor: 1,
+  patch: 2,
+  preReleases: [{ identifier: "alpha", value: 3 }]
+});
 ```
 
 ### Incrementing the version
@@ -46,12 +47,12 @@ The following increment types can be applied when using `.increment(...)`:
 | `MAJOR` | Increments the `MAJOR` version core |
 | `MINOR` | Increments the `MINOR` version core |
 | `PATCH` | Increments the `PATCH` version core |
-| `PRERELEASE` | Increments the `PRERELEASE` or adds `-rc.1` in case no `PRERELEASE` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `-alpha.1`, `-rc.7`) |
-| `BUILD` | Increments the `BUILD` or adds `+build.1` in case no `BUILD` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `+build.1`, `+attempt.3`) |
+| `PRERELEASE` | Increments the `PRERELEASE` or adds `-rc.1` in case no `PRERELEASE` is present on the version to be incremented.<br>You can specify the pre-release element to increment by providing the optional `modifier` parameter<br><br>This will manage pre-release identifiers a key-value pair (e.g. `-alpha.1`, `-rc.7`) |
 
 ## Calendar Versioning
 
-> :bulb: Please refer to the [CalVer] specification for information about Calendar Versioning.
+> [!INFO]
+> Please refer to the [CalVer] specification for information about Calendar Versioning.
 
 ```ts
 import { CalVer } from "@dev-build-deploy/version-it";
@@ -62,17 +63,17 @@ const calverFormat = "YYYY.0M.MICRO";
 const currentVersion = new CalVer(calverFormat, "2023.01.12-alpha.2");
 
 // Create from interface
-const previousVersion = new CalVer(
+const constructed = new CalVer(
   calverFormat, {
     major: 2023,
     minor: 1,
     micro: 12,
-    modified: "alpha.1"
+    modifiers: [{ identifier: "alpha", version: 1 }]
   }
 );
 
 // Update the calendar related version (e.g. YYYY, MM, WW, DD)
-const newVersion = currentVersion.increment("CALENDAR");
+const newVersion = currentVersion.increment("CALENDAR"); // => 2024.0.0
 ```
 
 ### CalVer Formatting
@@ -98,6 +99,9 @@ Formatting is provided as a string, where each version core (`MAJOR`, `MINOR`, `
 
 ### Incrementing the version
 
+> [!WARNING]
+> The `MODIFIER` is using the same precedence rules as "Pre-releases" in the [SemVer] specification.
+
 The following increment types can be applied when using `.increment(...)`:
 
 | Type | Description |
@@ -106,7 +110,7 @@ The following increment types can be applied when using `.increment(...)`:
 | `MAJOR` | Increments (+1) the version associated with `MAJOR` formatting |
 | `MINOR` | Increments (+1) the version associated with `MINOR` formatting |
 | `MICRO` | Increments (+1) the version associated with `MICRO` formatting |
-| `MODIFIER` | Increments the `MODIFIER` or adds `build.1` in case no `MODIFIER` is present on the version to be incremented.<br><br>Requires a key-value pair (e.g. `alpha.1`, `build.7`)|
+| `MODIFIER` | Increments the `MODIFIER` or adds `-rc.1` in case no `MODIFIER` is present on the version to be incremented.<br>You can specify the modifier element to increment by providing the optional `modifier` parameter<br><br>This will manage pre-release identifiers a key-value pair (e.g. `-alpha.1`, `-rc.7`)|
 
 ## Comparing and sorting
 
@@ -129,7 +133,6 @@ const sortedVersions = unsortedVersions.sort((a, b) => a.compareTo(b));
 if (newVersion.isGreaterThan(previousVersion)) {
   // Hurray..!
 }
-
 ```
 
 ## Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 export { ISemVer, SemVer, SemVerIncrement } from "./semver";
 export { ICalVer, CalVer, CalVerIncrement } from "./calver";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,7 +1,7 @@
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 /**
  * Comparable interface
@@ -61,6 +61,7 @@ export interface IVersion<T, Y> extends IComparable<T> {
   /**
    * Increments the version by the provided type
    * @param type Type of increment
+   * @param modifier Modifier to increment
    */
-  increment(type: Y): T;
+  increment(type: Y, modifier?: string): T;
 }

--- a/src/modifiers.ts
+++ b/src/modifiers.ts
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @internal
+ */
+export type Modifier = { identifier?: string; value: number; length: number };
+
+/**
+ * Parses the provided string into a list of modifiers; i.e.:
+ * - alpha.1 => [{ identifier: "alpha", value: 1, length: 1 }]
+ * - beta.01 => [{ identifier: "beta", value: 1, length: 2 }]
+ * - alpha.beta.2 => [{ identifier: "alpha", value: 0, length: 0 }, { identifier: "beta", value: 2, length: 1 }]
+ * - 1.0.0 => []
+ * @param value String containing zero or more modifiers
+ * @returns List of modifiers
+ * @internal
+ */
+export function getModifiers(value?: string): Modifier[] {
+  const modifiers: Modifier[] = [];
+
+  let nextModifier: Modifier | undefined = undefined;
+  for (const element of value ? value.split(".") : []) {
+    if (isNaN(Number(element))) {
+      if (nextModifier) {
+        modifiers.push(nextModifier);
+      }
+      nextModifier = { identifier: element, value: 0, length: 0 };
+    } else {
+      if (!nextModifier) {
+        modifiers.push({ identifier: undefined, value: Number(element), length: element.length });
+      } else {
+        nextModifier.value = Number(element);
+        nextModifier.length = element.length;
+        modifiers.push(nextModifier);
+        nextModifier = undefined;
+      }
+    }
+  }
+
+  if (nextModifier) modifiers.push(nextModifier);
+
+  return modifiers;
+}
+
+/**
+ * Increments the modifier with the provided identifier
+ * @param modifiers list of modifiers
+ * @param identifier identifier to increment
+ * @returns List of modifiers with the incremented identifier
+ * @internal
+ */
+export function incrementModifier(modifiers: Modifier[], identifier: string): Modifier[] {
+  const modifiersCopy = [...modifiers];
+  const element = modifiersCopy.findIndex(m => m.identifier === identifier);
+
+  if (element === -1) {
+    return [...modifiersCopy, { identifier, value: 1, length: 1 }];
+  }
+
+  const nextVersion = modifiersCopy[element].value + 1;
+
+  modifiersCopy[element] = {
+    ...modifiersCopy[element],
+    value: nextVersion,
+    length: nextVersion.toString().length,
+  };
+
+  return modifiersCopy;
+}
+
+/**
+ * Compares to lists of Modifiers
+ * @param a Left side of comparison
+ * @param b Right side of comparison
+ * @returns 1 if a is greater than b, -1 if a is less than b, 0 if a is equal to b
+ */
+export function compareModifiers(a: Modifier[], b: Modifier[]): number {
+  if (a.length < b.length) return 1;
+  if (a.length > b.length) return -1;
+
+  // 1.0.0.alpha.1 < 1.0.0.alpha.2 < 1.0.0
+  for (let idx = 0; idx < a.length; idx++) {
+    const identifierComp = (a[idx].identifier ?? "").localeCompare(b[idx].identifier ?? "");
+
+    if (identifierComp !== 0) return identifierComp;
+
+    if (a[idx].value === b[idx].value) continue;
+    return a[idx].value > b[idx].value ? 1 : -1;
+  }
+
+  return 0;
+}
+
+/**
+ * Converts a list of modifiers to a string
+ * @param modifiers List of modifiers
+ * @returns String representation of the modifiers
+ * @internal
+ */
+export function modifiersToString(modifiers: Modifier[]): string {
+  const elements = modifiers.map(modifier =>
+    modifier.identifier
+      ? `${modifier.identifier}${modifier.length > 0 ? "." + modifier.value : ""}`
+      : `${modifier.value}`
+  );
+
+  return modifiers.length > 0 ? "-" + elements.join(".") : "";
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,21 +1,7 @@
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
-
-/**
- * Returns a key-value pair from the provided identifier (e.g. alpha.1 => { key: "alpha.", value: 1 })
- * @param identifier Identifier to parse (e.g. alpha.1)
- * @returns Identifier value (e.g. 1)
- * @internal
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
  */
-export function getKeyValuePair(value?: string): { key: string; value: number } | undefined {
-  const kvpRegex = /^([a-zA-Z-]+)[.]([0-9]+)$/;
-  const match = kvpRegex.exec(value ?? "");
-  if (match === null) return;
-
-  return { key: match[1], value: parseInt(match[2]) };
-}
 
 /**
  * Returns the week number of the current date (ISO 8601)
@@ -32,4 +18,11 @@ export function getISO8601WeekNumber(): number {
     date.setMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
   }
   return 1 + Math.ceil((firstThursday - date.valueOf()) / 604800000);
+}
+
+export function compareNumbers(a: number, b: number): number {
+  if (a > b) return 1;
+  else if (a < b) return -1;
+
+  return 0;
 }

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -1,7 +1,7 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 import * as calver from "../src/calver";
 
@@ -98,7 +98,7 @@ describe("String to CalVer", () => {
     ];
 
     for (const [version, format] of versions) {
-      expect(new calver.CalVer(format, version).toString()).toBe(version);
+      expect(calver.CalVer.fromString(format, version).toString()).toBe(version);
     }
   });
 
@@ -116,12 +116,12 @@ describe("String to CalVer", () => {
       ["07.1", "0D.MINOR", "13.0"],
       ["07.1.3", "0D.MAJOR.MINOR", "13.0.0"],
       // Equal versions
-      ["2023.1", "YYYY.MINOR", "2023.1-build.1"],
-      ["2023.1-build.1", "YYYY.MINOR", "2023.1-build.2"],
+      ["2023.1", "YYYY.MINOR", "2023.1"],
+      ["2023.1-build.1", "YYYY.MINOR", "2023.1-build.1"],
     ];
 
     for (const [version, format, expectations] of versions) {
-      expect(new calver.CalVer(format, version).increment("CALENDAR").toString()).toBe(expectations);
+      expect(calver.CalVer.fromString(format, version).increment("CALENDAR").toString()).toBe(expectations);
     }
   });
 
@@ -131,6 +131,8 @@ describe("String to CalVer", () => {
       ["2022.1", "YYYY.MAJOR", "2022.2"],
       ["22.1", "YY.MAJOR", "22.2"],
       ["09.1.3", "0D.MAJOR.MINOR", "09.2.0"],
+      // Increment pre-release modifier
+      ["10.2.4-alpha.1", "DD.MAJOR.MINOR", "10.3.0"],
       // Incorrect increments
       ["2022.1", "YYYY.MINOR", ""],
       ["22.1", "YY.DD", ""],
@@ -141,9 +143,9 @@ describe("String to CalVer", () => {
 
     for (const [version, format, expectations] of versions) {
       if (expectations !== "") {
-        expect(new calver.CalVer(format, version).increment("MAJOR").toString()).toBe(expectations);
+        expect(calver.CalVer.fromString(format, version).increment("MAJOR").toString()).toBe(expectations);
       } else {
-        expect(() => new calver.CalVer(format, version).increment("MAJOR")).toThrow();
+        expect(() => calver.CalVer.fromString(format, version).increment("MAJOR")).toThrow();
       }
     }
   });
@@ -153,6 +155,8 @@ describe("String to CalVer", () => {
       // New versions
       ["2022.1.2", "YYYY.MAJOR.MINOR", "2022.1.3"],
       ["22.1", "YY.MINOR", "22.2"],
+      // Pre-release modifier
+      ["22.1-alpha.1", "YY.MINOR", "22.2"],
       // Incorrect increments
       ["2022.1", "YYYY.MAJOR", ""],
       ["22.1", "YY.DD", ""],
@@ -163,18 +167,20 @@ describe("String to CalVer", () => {
 
     for (const [version, format, expectations] of versions) {
       if (expectations !== "") {
-        expect(new calver.CalVer(format, version).increment("MINOR").toString()).toBe(expectations);
+        expect(calver.CalVer.fromString(format, version).increment("MINOR").toString()).toBe(expectations);
       } else {
-        expect(() => new calver.CalVer(format, version).increment("MINOR")).toThrow();
+        expect(() => calver.CalVer.fromString(format, version).increment("MINOR")).toThrow();
       }
     }
   });
 
-  test("Update Minor", () => {
+  test("Update Micro", () => {
     const versions = [
       // New versions
       ["2022.1.2", "YYYY.MINOR.MICRO", "2022.1.3"],
       ["22.1", "YY.MICRO", "22.2"],
+      // Pre-release modifier
+      ["22.1-alpha.1", "YY.MICRO", "22.2"],
       // Incorrect increments
       ["2022.1", "YYYY.MAJOR", ""],
       ["22.1", "YY.DD", ""],
@@ -185,9 +191,9 @@ describe("String to CalVer", () => {
 
     for (const [version, format, expectations] of versions) {
       if (expectations !== "") {
-        expect(new calver.CalVer(format, version).increment("MICRO").toString()).toBe(expectations);
+        expect(calver.CalVer.fromString(format, version).increment("MICRO").toString()).toBe(expectations);
       } else {
-        expect(() => new calver.CalVer(format, version).increment("MICRO")).toThrow();
+        expect(() => calver.CalVer.fromString(format, version).increment("MICRO")).toThrow();
       }
     }
   });
@@ -198,15 +204,15 @@ describe("String to CalVer", () => {
       ["2022.1.2", "YYYY.MAJOR.MINOR", "2022.1.2-build.1"],
       ["22.1-build.3", "YY.MINOR", "22.1-build.4"],
       // Incorrect increments
-      ["2022.1-alpha", "YYYY.MAJOR", ""],
-      ["22.1-alpha1", "YY.DD", ""],
+      ["2022.1-alpha", "YY.MAJOR", ""],
+      ["22.1-alpha1", "YYYY.DD", ""],
     ];
 
     for (const [version, format, expectations] of versions) {
       if (expectations !== "") {
-        expect(new calver.CalVer(format, version).increment("MODIFIER").toString()).toBe(expectations);
+        expect(calver.CalVer.fromString(format, version).increment("MODIFIER", "build").toString()).toBe(expectations);
       } else {
-        expect(() => new calver.CalVer(format, version).increment("MODIFIER")).toThrow();
+        expect(() => calver.CalVer.fromString(format, version).increment("MODIFIER")).toThrow();
       }
     }
   });
@@ -231,7 +237,7 @@ describe("Comparators", () => {
       ["MAJOR.MINOR.MICRO", "2022.2.2", "2023.2.2", "-1"],
       ["MAJOR.MINOR.MICRO", "2024.1.1", "2023.2.2", "1"],
       // Modifiers
-      ["YYYY.MINOR", "2023.1", "2023.1-build.1", "-1"],
+      ["YYYY.MINOR", "2023.1", "2023.1-build.1", "1"],
       ["YYYY.MINOR", "2023.2", "2023.1-build.1", "1"],
       ["YYYY.MINOR", "2023.1-build.1", "2023.1-build.1", "0"],
       ["YYYY.MINOR", "2023.1-build.2", "2023.1-build.1", "1"],
@@ -249,8 +255,8 @@ describe("Comparators", () => {
     ];
 
     for (const [format, a, b, expectations] of versions) {
-      const aC = new calver.CalVer(format, a);
-      const bC = new calver.CalVer(format, b);
+      const aC = calver.CalVer.fromString(format, a);
+      const bC = calver.CalVer.fromString(format, b);
       expect(aC.compareTo(bC)).toBe(parseInt(expectations));
       expect(aC.isEqualTo(bC)).toBe(expectations === "0");
       expect(aC.isGreaterThan(bC)).toBe(expectations === "1");

--- a/test/modifiers.test.ts
+++ b/test/modifiers.test.ts
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+import { getModifiers, incrementModifier, modifiersToString } from "../src/modifiers";
+
+describe("Determine Pre-Releases", () => {
+  test("No Pre-Releases", () => {
+    expect(getModifiers()).toStrictEqual([]);
+    expect(getModifiers("")).toStrictEqual([]);
+  });
+
+  test("Multi Pre-Release", () => {
+    expect(getModifiers("1")).toStrictEqual([{ identifier: undefined, value: 1, length: 1 }]);
+    expect(getModifiers("alpha")).toStrictEqual([{ identifier: "alpha", value: 0, length: 0 }]);
+    expect(getModifiers("alpha.1")).toStrictEqual([{ identifier: "alpha", value: 1, length: 1 }]);
+    expect(getModifiers("alpha.001")).toStrictEqual([{ identifier: "alpha", value: 1, length: 3 }]);
+    expect(getModifiers("alpha.101")).toStrictEqual([{ identifier: "alpha", value: 101, length: 3 }]);
+    expect(getModifiers("alpha.beta.2")).toStrictEqual([
+      { identifier: "alpha", value: 0, length: 0 },
+      { identifier: "beta", value: 2, length: 1 },
+    ]);
+    expect(getModifiers("1.2.3")).toStrictEqual([
+      { identifier: undefined, value: 1, length: 1 },
+      { identifier: undefined, value: 2, length: 1 },
+      { identifier: undefined, value: 3, length: 1 },
+    ]);
+  });
+
+  test("Increment", () => {
+    expect(incrementModifier([], "alpha")).toStrictEqual([{ identifier: "alpha", value: 1, length: 1 }]);
+    expect(incrementModifier([{ identifier: "alpha", value: 1, length: 1 }], "alpha")).toStrictEqual([
+      { identifier: "alpha", value: 2, length: 1 },
+    ]);
+    expect(incrementModifier([{ identifier: "alpha", value: 1, length: 1 }], "beta")).toStrictEqual([
+      { identifier: "alpha", value: 1, length: 1 },
+      { identifier: "beta", value: 1, length: 1 },
+    ]);
+  });
+
+  test("toString", () => {
+    expect(modifiersToString([{ identifier: "alpha", value: 1, length: 1 }])).toBe("-alpha.1");
+    expect(
+      modifiersToString([
+        { identifier: "alpha", value: 1, length: 1 },
+        { identifier: "beta", value: 1, length: 1 },
+      ])
+    ).toBe("-alpha.1.beta.1");
+  });
+});

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -1,7 +1,7 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 import { SemVer } from "../src/semver";
 
@@ -20,7 +20,7 @@ describe("String to SemVer", () => {
       "1.0.0",
     ];
     versions.forEach(v => {
-      expect(new SemVer(v)?.toString()).toBe(v);
+      expect(SemVer.fromString(v)?.toString()).toBe(v);
     });
   });
 
@@ -28,7 +28,7 @@ describe("String to SemVer", () => {
     const versions = ["0.0.1.1", "0.1.x", "0.1.1?rc.1", "v87", "2023-02-02"];
     versions.forEach(v => {
       expect(() => {
-        new SemVer(v);
+        SemVer.fromString(v);
       }).toThrow();
     });
   });
@@ -36,25 +36,25 @@ describe("String to SemVer", () => {
 
 describe("Comparators", () => {
   test("isEqualTo", () => {
-    expect(new SemVer("1.0.0")?.isEqualTo(new SemVer("1.0.0"))).toBe(true);
-    expect(new SemVer("1.0.0-rc.1")?.isEqualTo(new SemVer("1.0.0-rc.1"))).toBe(true);
-    expect(new SemVer("1.0.0-rc.1")?.isEqualTo(new SemVer("1.0.0"))).toBe(false);
-    expect(new SemVer("1.0.1")?.isEqualTo(new SemVer("1.0.0"))).toBe(false);
-    expect(new SemVer("1.0.0-rc.1+build.1")?.isEqualTo(new SemVer("1.0.0-rc.1"))).toBe(false);
+    expect(SemVer.fromString("1.0.0")?.isEqualTo(SemVer.fromString("1.0.0"))).toBe(true);
+    expect(SemVer.fromString("1.0.0-rc.1")?.isEqualTo(SemVer.fromString("1.0.0-rc.1"))).toBe(true);
+    expect(SemVer.fromString("1.0.0-rc.1")?.isEqualTo(SemVer.fromString("1.0.0"))).toBe(false);
+    expect(SemVer.fromString("1.0.1")?.isEqualTo(SemVer.fromString("1.0.0"))).toBe(false);
+    expect(SemVer.fromString("1.0.0-rc.1+build.1")?.isEqualTo(SemVer.fromString("1.0.0-rc.1"))).toBe(true);
   });
 
   test("isGreaterThan", () => {
-    expect(new SemVer("1.0.0")?.isGreaterThan(new SemVer("1.0.0"))).toBe(false);
-    expect(new SemVer("1.0.0")?.isGreaterThan(new SemVer("1.0.0-rc.1"))).toBe(true);
-    expect(new SemVer("1.0.0-rc.1")?.isGreaterThan(new SemVer("1.0.0-rc.2"))).toBe(false);
-    expect(new SemVer("1.0.0-rc.1+build.1")?.isGreaterThan(new SemVer("1.0.0-rc.1"))).toBe(true);
+    expect(SemVer.fromString("1.0.0")?.isGreaterThan(SemVer.fromString("1.0.0"))).toBe(false);
+    expect(SemVer.fromString("1.0.0")?.isGreaterThan(SemVer.fromString("1.0.0-rc.1"))).toBe(true);
+    expect(SemVer.fromString("1.0.0-rc.1")?.isGreaterThan(SemVer.fromString("1.0.0-rc.2"))).toBe(false);
+    expect(SemVer.fromString("1.0.0-rc.1+build.1")?.isGreaterThan(SemVer.fromString("1.0.0-rc.1"))).toBe(false);
   });
 
   test("isLessThan", () => {
-    expect(new SemVer("1.0.0")?.isLessThan(new SemVer("1.0.0"))).toBe(false);
-    expect(new SemVer("1.0.0")?.isLessThan(new SemVer("1.0.0-rc.1"))).toBe(false);
-    expect(new SemVer("1.0.0-rc.1")?.isLessThan(new SemVer("1.0.0-rc.2"))).toBe(true);
-    expect(new SemVer("1.0.0-rc.1+build.1")?.isLessThan(new SemVer("1.0.0-rc.1"))).toBe(false);
+    expect(SemVer.fromString("1.0.0")?.isLessThan(SemVer.fromString("1.0.0"))).toBe(false);
+    expect(SemVer.fromString("1.0.0")?.isLessThan(SemVer.fromString("1.0.0-rc.1"))).toBe(false);
+    expect(SemVer.fromString("1.0.0-rc.1")?.isLessThan(SemVer.fromString("1.0.0-rc.2"))).toBe(true);
+    expect(SemVer.fromString("1.0.0-rc.1+build.1")?.isLessThan(SemVer.fromString("1.0.0-rc.1"))).toBe(false);
   });
 
   test("Exhaustive compare", () => {
@@ -65,9 +65,9 @@ describe("Comparators", () => {
       ["0.0.2", "0.0.2-rc.1", 1],
       ["0.0.2", "0.0.2-rc.2", 1],
       ["0.0.2", "0.0.2-rc.3", 1],
-      ["0.0.2", "0.0.2+build.1", -1],
-      ["0.0.2", "0.0.2+build.2", -1],
-      ["0.0.2", "0.0.2+build.3", -1],
+      ["0.0.2", "0.0.2+build.1", 0],
+      ["0.0.2", "0.0.2+build.2", 0],
+      ["0.0.2", "0.0.2+build.3", 0],
       ["0.0.2", "0.0.2-rc.1+build.1", 1],
       ["0.0.2", "0.0.2-rc.2+build.1", 1],
       ["0.0.2", "0.0.2-rc.3+build.1", 1],
@@ -88,13 +88,13 @@ describe("Comparators", () => {
       ["0.0.2-rc.2", "0.0.2+build.2", -1],
       ["0.0.2-rc.2", "0.0.2+build.3", -1],
       ["0.0.2-rc.2", "0.0.2-rc.1+build.1", 1],
-      ["0.0.2-rc.2", "0.0.2-rc.2+build.1", -1],
+      ["0.0.2-rc.2", "0.0.2-rc.2+build.1", 0],
       ["0.0.2-rc.2", "0.0.2-rc.3+build.1", -1],
       ["0.0.2-rc.2", "0.0.2-rc.1+build.2", 1],
-      ["0.0.2-rc.2", "0.0.2-rc.2+build.2", -1],
+      ["0.0.2-rc.2", "0.0.2-rc.2+build.2", 0],
       ["0.0.2-rc.2", "0.0.2-rc.3+build.2", -1],
       ["0.0.2-rc.2", "0.0.2-rc.1+build.3", 1],
-      ["0.0.2-rc.2", "0.0.2-rc.2+build.3", -1],
+      ["0.0.2-rc.2", "0.0.2-rc.2+build.3", 0],
       ["0.0.2-rc.2", "0.0.2-rc.3+build.3", -1],
       ["0.0.2-rc.2", "0.0.2-alpha.1", 1],
       ["0.0.2-rc.2", "0.0.2-zeta.1", -1],
@@ -104,11 +104,11 @@ describe("Comparators", () => {
       ["0.0.2+build.2", "0.0.2-rc.1", 1],
       ["0.0.2+build.2", "0.0.2-rc.2", 1],
       ["0.0.2+build.2", "0.0.2-rc.3", 1],
-      ["0.0.2+build.2", "0.0.2+build.1", 1],
+      ["0.0.2+build.2", "0.0.2+build.1", 0],
       ["0.0.2+build.2", "0.0.2+build.2", 0],
-      ["0.0.2+build.2", "0.0.2+build.3", -1],
-      ["0.0.2+build.2", "0.0.2+alpha.2", 1],
-      ["0.0.2+build.2", "0.0.2+zeta.2", -1],
+      ["0.0.2+build.2", "0.0.2+build.3", 0],
+      ["0.0.2+build.2", "0.0.2+alpha.2", 0],
+      ["0.0.2+build.2", "0.0.2+zeta.2", 0],
       ["0.0.2+build.2", "0.0.2-rc.1+build.1", 1],
       ["0.0.2+build.2", "0.0.2-rc.2+build.1", 1],
       ["0.0.2+build.2", "0.0.2-rc.3+build.1", 1],
@@ -124,13 +124,13 @@ describe("Comparators", () => {
       ["0.0.2-rc.2+build.2", "0.0.2", -1],
       ["0.0.2-rc.2+build.2", "0.0.3", -1],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.1", 1],
-      ["0.0.2-rc.2+build.2", "0.0.2-rc.2", 1],
+      ["0.0.2-rc.2+build.2", "0.0.2-rc.2", 0],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.3", -1],
       ["0.0.2-rc.2+build.2", "0.0.2+build.1", -1],
       ["0.0.2-rc.2+build.2", "0.0.2+build.2", -1],
       ["0.0.2-rc.2+build.2", "0.0.2+build.3", -1],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.1+build.1", 1],
-      ["0.0.2-rc.2+build.2", "0.0.2-rc.2+build.1", 1],
+      ["0.0.2-rc.2+build.2", "0.0.2-rc.2+build.1", 0],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.3+build.1", -1],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.1+build.2", 1],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.2+build.2", 0],
@@ -138,12 +138,12 @@ describe("Comparators", () => {
       ["0.0.2-rc.2+build.2", "0.0.2-zeta.2+build.2", -1],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.3+build.2", -1],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.1+build.3", 1],
-      ["0.0.2-rc.2+build.2", "0.0.2-rc.2+build.3", -1],
+      ["0.0.2-rc.2+build.2", "0.0.2-rc.2+build.3", 0],
       ["0.0.2-rc.2+build.2", "0.0.2-rc.3+build.3", -1],
     ];
     versions.forEach(([a, b, expected]) => {
-      const aSemVer = new SemVer(a as string);
-      const bSemVer = new SemVer(b as string);
+      const aSemVer = SemVer.fromString(a as string);
+      const bSemVer = SemVer.fromString(b as string);
       const compareResult = aSemVer.compareTo(bSemVer);
       if (compareResult !== expected) {
         console.log(a, expected === 0 ? "=" : expected === -1 ? "<" : ">", b);
@@ -155,57 +155,48 @@ describe("Comparators", () => {
 
 describe("increment version", () => {
   test("increment major", () => {
-    expect(new SemVer("0.0.1")?.increment("MAJOR").toString()).toBe("1.0.0");
-    expect(new SemVer("0.1.0")?.increment("MAJOR").toString()).toBe("1.0.0");
-    expect(new SemVer("1.0.0")?.increment("MAJOR").toString()).toBe("2.0.0");
-    expect(new SemVer("1.0.0-rc.1")?.increment("MAJOR").toString()).toBe("2.0.0");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("MAJOR").toString()).toBe("2.0.0");
+    expect(SemVer.fromString("0.0.1")?.increment("MAJOR").toString()).toBe("1.0.0");
+    expect(SemVer.fromString("0.1.0")?.increment("MAJOR").toString()).toBe("1.0.0");
+    expect(SemVer.fromString("1.0.0")?.increment("MAJOR").toString()).toBe("2.0.0");
+    expect(SemVer.fromString("1.0.0-rc.1")?.increment("MAJOR").toString()).toBe("2.0.0");
+    expect(SemVer.fromString("1.0.0-rc.2+build.1")?.increment("MAJOR").toString()).toBe("2.0.0");
   });
 
   test("increment minor", () => {
-    expect(new SemVer("0.0.1")?.increment("MINOR").toString()).toBe("0.1.0");
-    expect(new SemVer("0.1.0")?.increment("MINOR").toString()).toBe("0.2.0");
-    expect(new SemVer("1.0.0")?.increment("MINOR").toString()).toBe("1.1.0");
-    expect(new SemVer("1.0.0-rc.1")?.increment("MINOR").toString()).toBe("1.1.0");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("MINOR").toString()).toBe("1.1.0");
+    expect(SemVer.fromString("0.0.1")?.increment("MINOR").toString()).toBe("0.1.0");
+    expect(SemVer.fromString("0.1.0")?.increment("MINOR").toString()).toBe("0.2.0");
+    expect(SemVer.fromString("1.0.0")?.increment("MINOR").toString()).toBe("1.1.0");
+    expect(SemVer.fromString("1.0.0-rc.1")?.increment("MINOR").toString()).toBe("1.1.0");
+    expect(SemVer.fromString("1.0.0-rc.2+build.1")?.increment("MINOR").toString()).toBe("1.1.0");
   });
 
   test("increment patch", () => {
-    expect(new SemVer("0.0.1")?.increment("PATCH").toString()).toBe("0.0.2");
-    expect(new SemVer("0.1.0")?.increment("PATCH").toString()).toBe("0.1.1");
-    expect(new SemVer("1.0.0")?.increment("PATCH").toString()).toBe("1.0.1");
-    expect(new SemVer("1.0.0-rc.1")?.increment("PATCH").toString()).toBe("1.0.1");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("PATCH").toString()).toBe("1.0.1");
+    expect(SemVer.fromString("0.0.1")?.increment("PATCH").toString()).toBe("0.0.2");
+    expect(SemVer.fromString("0.1.0")?.increment("PATCH").toString()).toBe("0.1.1");
+    expect(SemVer.fromString("1.0.0")?.increment("PATCH").toString()).toBe("1.0.1");
+    expect(SemVer.fromString("1.0.0-rc.1")?.increment("PATCH").toString()).toBe("1.0.1");
+    expect(SemVer.fromString("1.0.0-rc.2+build.1")?.increment("PATCH").toString()).toBe("1.0.1");
   });
 
   test("increment preRelease", () => {
-    expect(new SemVer("0.0.1")?.increment("PRERELEASE").toString()).toBe("0.0.1-rc.1");
-    expect(new SemVer("0.1.0-rc.1")?.increment("PRERELEASE").toString()).toBe("0.1.0-rc.2");
-    expect(new SemVer("1.0.0+build.3")?.increment("PRERELEASE").toString()).toBe("1.0.0-rc.1");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("PRERELEASE").toString()).toBe("1.0.0-rc.3");
-  });
-
-  test("increment build", () => {
-    expect(new SemVer("0.0.1")?.increment("BUILD").toString()).toBe("0.0.1+build.1");
-    expect(new SemVer("0.1.0-rc.1")?.increment("BUILD").toString()).toBe("0.1.0-rc.1+build.1");
-    expect(new SemVer("1.0.0+build.1")?.increment("BUILD").toString()).toBe("1.0.0+build.2");
-    expect(new SemVer("1.0.0-rc.2+build.1")?.increment("BUILD").toString()).toBe("1.0.0-rc.2+build.2");
+    expect(SemVer.fromString("0.0.1")?.increment("PRERELEASE").toString()).toBe("0.0.1-rc.1");
+    expect(SemVer.fromString("0.1.0-rc.1")?.increment("PRERELEASE").toString()).toBe("0.1.0-rc.2");
+    expect(SemVer.fromString("1.0.0+build.3")?.increment("PRERELEASE").toString()).toBe("1.0.0-rc.1");
+    expect(SemVer.fromString("1.0.0-rc.2+build.1")?.increment("PRERELEASE").toString()).toBe("1.0.0-rc.3");
   });
 
   test("Support prefix", () => {
     expect(
-      new SemVer("v0.0.0", "v")
+      SemVer.fromString("v0.0.0", "v")
         ?.increment("MAJOR")
         .increment("MINOR")
         .increment("PATCH")
         .increment("PRERELEASE")
-        .increment("BUILD")
         .toString()
-    ).toBe("v1.1.1-rc.1+build.1");
+    ).toBe("v1.1.1-rc.1");
     expect(
-      new SemVer("v0.0.0", "v")
-        ?.increment("BUILD")
-        .increment("PRERELEASE")
+      SemVer.fromString("v0.0.0", "v")
+        ?.increment("PRERELEASE")
         .increment("PATCH")
         .increment("MINOR")
         .increment("MAJOR")


### PR DESCRIPTION
- Both SemVer and CalVer are now sharing the same logic between their `modifier` (CalVer) and `prerelease` (SemVer), indicating that these are pre-releases.
- Multiple modifiers can now be added to a single version
- When incrementing `CALENDAR` in CalVer does not lead to a newer version, no longer is a `-build.1` modifier added, as this would denote a pre-release.
- The `build` metadata is no longer taken into account when ordering SemVer versions, as per specification. In addition, it is no longer possible to increment this element using `increment(...)`. Instead you will need to add the `build` parameter manually when needed
- The constructor of both CalVer and SemVer no longer support a string-version as input, instead using the `SemVer.fromString()` and `CalVer.fromString()` static functions.