### PR TITLE
fix: expose Modifier type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,5 @@
 
 export { ISemVer, SemVer, SemVerIncrement } from "./semver";
 export { ICalVer, CalVer, CalVerIncrement } from "./calver";
+export { Modifier } from "./modifiers";
 export { IComparable, IVersion } from "./interfaces";

--- a/src/modifiers.ts
+++ b/src/modifiers.ts
@@ -4,7 +4,11 @@
  */
 
 /**
- * @internal
+ * Pre-release modifier
+ * @type Modifier
+ * @member identifier Identifier of the modifier
+ * @member value Value of the modifier
+ * @member length Length of the value
  */
 export type Modifier = { identifier?: string; value: number; length: number };
 


### PR DESCRIPTION
We have added the Modifier type to the public API, as it is expected that users can modify the list of pre-releases.