### PR TITLE
feat!: return null in fromString() and fromFormattedString()

### DIFF
--- a/src/calver.ts
+++ b/src/calver.ts
@@ -100,20 +100,19 @@ export class CalVer implements IVersion<CalVer, CalVerIncrement>, ICalVer {
    * @param format CalVer formatting
    * @param versin Version string
    * @param prefix Prefix associated with the version
-   * @returns CalVer
-   * @throws Error when the version string is not compatible with Calendar Versioning
+   * @returns CalVer or null if the version string is invalid
    */
-  static fromString(format: string | IFormat, version: string, prefix?: string): CalVer {
+  static fromString(format: string | IFormat, version: string, prefix?: string): CalVer | null {
     format = typeof format === "string" ? formatFromString(format) : format;
 
     if (prefix !== undefined) {
-      if (!version.startsWith(prefix)) throw new Error("Incorrect CalVer, missing prefix");
+      if (!version.startsWith(prefix)) return null;
       version = version.substring(prefix.length);
     }
 
     const groups = format.regex.exec(version)?.groups;
     if (groups === undefined) {
-      throw new Error("Could not parse CalVer");
+      return null;
     }
 
     return new CalVer(

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -71,19 +71,18 @@ export class SemVer implements IVersion<SemVer, SemVerIncrement>, ISemVer {
    * Creates a SemVer object from a string
    * @param version Version string
    * @param prefix Prefix associated with the version
-   * @returns SemVer
-   * @throws Error when the version string is not compatible with Semantic Versioning
+   * @returns SemVer or null if the version string is invalid
    */
-  static fromString(version: string, prefix?: string): SemVer {
+  static fromString(version: string, prefix?: string): SemVer | null {
     // Handle prefix
     if (prefix !== undefined) {
-      if (!version.startsWith(prefix)) throw new Error("Incorrect SemVer, missing prefix");
+      if (!version.startsWith(prefix)) return null;
       version = version.substring(prefix.length);
     }
 
     // SemVer regex
     const groups = SEMVER_REGEX.exec(version)?.groups;
-    if (groups === undefined) throw new Error("Could not parse SemVer");
+    if (groups === undefined) return null;
 
     const semver: ISemVer = {
       prefix,

--- a/test/calver.test.ts
+++ b/test/calver.test.ts
@@ -98,7 +98,7 @@ describe("String to CalVer", () => {
     ];
 
     for (const [version, format] of versions) {
-      expect(calver.CalVer.fromString(format, version).toString()).toBe(version);
+      expect(calver.CalVer.fromString(format, version)?.toString()).toBe(version);
     }
   });
 
@@ -121,7 +121,7 @@ describe("String to CalVer", () => {
     ];
 
     for (const [version, format, expectations] of versions) {
-      expect(calver.CalVer.fromString(format, version).increment("CALENDAR").toString()).toBe(expectations);
+      expect(calver.CalVer.fromString(format, version)?.increment("CALENDAR").toString()).toBe(expectations);
     }
   });
 
@@ -143,9 +143,9 @@ describe("String to CalVer", () => {
 
     for (const [version, format, expectations] of versions) {
       if (expectations !== "") {
-        expect(calver.CalVer.fromString(format, version).increment("MAJOR").toString()).toBe(expectations);
+        expect(calver.CalVer.fromString(format, version)?.increment("MAJOR").toString()).toBe(expectations);
       } else {
-        expect(() => calver.CalVer.fromString(format, version).increment("MAJOR")).toThrow();
+        expect(() => calver.CalVer.fromString(format, version)?.increment("MAJOR")).toThrow();
       }
     }
   });
@@ -160,16 +160,16 @@ describe("String to CalVer", () => {
       // Incorrect increments
       ["2022.1", "YYYY.MAJOR", ""],
       ["22.1", "YY.DD", ""],
-      ["001", "0Y.MAJOR", ""],
+      ["001.9", "0Y.MAJOR", ""],
       ["1.1", "MM.MICRO", ""],
       ["01.1", "0M.WW", ""],
     ];
 
     for (const [version, format, expectations] of versions) {
       if (expectations !== "") {
-        expect(calver.CalVer.fromString(format, version).increment("MINOR").toString()).toBe(expectations);
+        expect(calver.CalVer.fromString(format, version)?.increment("MINOR").toString()).toBe(expectations);
       } else {
-        expect(() => calver.CalVer.fromString(format, version).increment("MINOR")).toThrow();
+        expect(() => calver.CalVer.fromString(format, version)?.increment("MINOR")).toThrow();
       }
     }
   });
@@ -191,9 +191,9 @@ describe("String to CalVer", () => {
 
     for (const [version, format, expectations] of versions) {
       if (expectations !== "") {
-        expect(calver.CalVer.fromString(format, version).increment("MICRO").toString()).toBe(expectations);
+        expect(calver.CalVer.fromString(format, version)?.increment("MICRO").toString()).toBe(expectations);
       } else {
-        expect(() => calver.CalVer.fromString(format, version).increment("MICRO")).toThrow();
+        expect(() => calver.CalVer.fromString(format, version)?.increment("MICRO")).toThrow();
       }
     }
   });
@@ -203,17 +203,12 @@ describe("String to CalVer", () => {
       // New versions
       ["2022.1.2", "YYYY.MAJOR.MINOR", "2022.1.2-build.1"],
       ["22.1-build.3", "YY.MINOR", "22.1-build.4"],
-      // Incorrect increments
-      ["2022.1-alpha", "YY.MAJOR", ""],
-      ["22.1-alpha1", "YYYY.DD", ""],
+      ["2022.1-alpha", "YYYY.MINOR", "2022.1-alpha.build.1"],
+      ["22.1-alpha1", "YY.DD", "22.1-alpha1.build.1"],
     ];
 
     for (const [version, format, expectations] of versions) {
-      if (expectations !== "") {
-        expect(calver.CalVer.fromString(format, version).increment("MODIFIER", "build").toString()).toBe(expectations);
-      } else {
-        expect(() => calver.CalVer.fromString(format, version).increment("MODIFIER")).toThrow();
-      }
+      expect(calver.CalVer.fromString(format, version)?.increment("MODIFIER", "build").toString()).toBe(expectations);
     }
   });
 });
@@ -257,6 +252,10 @@ describe("Comparators", () => {
     for (const [format, a, b, expectations] of versions) {
       const aC = calver.CalVer.fromString(format, a);
       const bC = calver.CalVer.fromString(format, b);
+      if (!aC || !bC) {
+        throw new Error(`Invalid CalVer: ${a} or ${b} for format ${format}`);
+      }
+
       expect(aC.compareTo(bC)).toBe(parseInt(expectations));
       expect(aC.isEqualTo(bC)).toBe(expectations === "0");
       expect(aC.isGreaterThan(bC)).toBe(expectations === "1");

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -27,36 +27,13 @@ describe("String to SemVer", () => {
   test("Bad Versions", () => {
     const versions = ["0.0.1.1", "0.1.x", "0.1.1?rc.1", "v87", "2023-02-02"];
     versions.forEach(v => {
-      expect(() => {
-        SemVer.fromString(v);
-      }).toThrow();
+      const version = SemVer.fromString(v);
+      expect(version).toBeNull();
     });
   });
 });
 
 describe("Comparators", () => {
-  test("isEqualTo", () => {
-    expect(SemVer.fromString("1.0.0")?.isEqualTo(SemVer.fromString("1.0.0"))).toBe(true);
-    expect(SemVer.fromString("1.0.0-rc.1")?.isEqualTo(SemVer.fromString("1.0.0-rc.1"))).toBe(true);
-    expect(SemVer.fromString("1.0.0-rc.1")?.isEqualTo(SemVer.fromString("1.0.0"))).toBe(false);
-    expect(SemVer.fromString("1.0.1")?.isEqualTo(SemVer.fromString("1.0.0"))).toBe(false);
-    expect(SemVer.fromString("1.0.0-rc.1+build.1")?.isEqualTo(SemVer.fromString("1.0.0-rc.1"))).toBe(true);
-  });
-
-  test("isGreaterThan", () => {
-    expect(SemVer.fromString("1.0.0")?.isGreaterThan(SemVer.fromString("1.0.0"))).toBe(false);
-    expect(SemVer.fromString("1.0.0")?.isGreaterThan(SemVer.fromString("1.0.0-rc.1"))).toBe(true);
-    expect(SemVer.fromString("1.0.0-rc.1")?.isGreaterThan(SemVer.fromString("1.0.0-rc.2"))).toBe(false);
-    expect(SemVer.fromString("1.0.0-rc.1+build.1")?.isGreaterThan(SemVer.fromString("1.0.0-rc.1"))).toBe(false);
-  });
-
-  test("isLessThan", () => {
-    expect(SemVer.fromString("1.0.0")?.isLessThan(SemVer.fromString("1.0.0"))).toBe(false);
-    expect(SemVer.fromString("1.0.0")?.isLessThan(SemVer.fromString("1.0.0-rc.1"))).toBe(false);
-    expect(SemVer.fromString("1.0.0-rc.1")?.isLessThan(SemVer.fromString("1.0.0-rc.2"))).toBe(true);
-    expect(SemVer.fromString("1.0.0-rc.1+build.1")?.isLessThan(SemVer.fromString("1.0.0-rc.1"))).toBe(false);
-  });
-
   test("Exhaustive compare", () => {
     const versions = [
       ["0.0.2", "0.0.1", 1],
@@ -144,11 +121,14 @@ describe("Comparators", () => {
     versions.forEach(([a, b, expected]) => {
       const aSemVer = SemVer.fromString(a as string);
       const bSemVer = SemVer.fromString(b as string);
-      const compareResult = aSemVer.compareTo(bSemVer);
-      if (compareResult !== expected) {
-        console.log(a, expected === 0 ? "=" : expected === -1 ? "<" : ">", b);
+      if (!aSemVer || !bSemVer) {
+        throw new Error(`Invalid SemVer: ${a} or ${b}`);
       }
-      expect(compareResult).toBe(expected);
+
+      expect(aSemVer.compareTo(bSemVer)).toBe(expected);
+      expect(aSemVer.isEqualTo(bSemVer)).toBe(expected === 0);
+      expect(aSemVer.isGreaterThan(bSemVer)).toBe(expected === 1);
+      expect(aSemVer.isLessThan(bSemVer)).toBe(expected === -1);
     });
   });
 });


### PR DESCRIPTION
Instead of throwing an exception, we now gracefully return `null` in case we cannot parse the provided SemVer or CalVer string.